### PR TITLE
Rewrite for runc

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,3 +1,4 @@
+apk
 gcr
 github
 Guice

--- a/action.sh
+++ b/action.sh
@@ -5,6 +5,24 @@ set -e
 docker_compose="docker-compose.yml"
 conf_check_output=$(mktemp)
 project_root=$(pwd)
+web_root=$(mktemp -d)
+web_port=9001
+web_pid=$(mktemp)
+
+start_web_server() {
+  (
+    cd "$web_root"
+    python3 -m http.server $web_port &
+    echo $! > "$web_pid"
+  )
+  export CONFIG_SERVER=$(hostname -i):$web_port
+}
+
+stop_web_server() {
+  if [ -s "$web_pid" ]; then
+    kill $(cat "$web_pid")
+  fi
+}
 
 neo4j_ready() {
   while ! curl -s 'http://localhost:7474' | grep -q '^{'; do sleep 1; done
@@ -39,9 +57,13 @@ expand_github_action_path() {
 expand_github_action_path
 add_all_problem_matchers
 perl -pe 's/NEO4J_CREDENTIALS/$ENV{NEO4J_CREDENTIALS}/' "$NEO4J_DOCKER_COMPOSE" > "$docker_compose"
+docker pull $VALIDATOR_IMAGE &
+pull_pid=$!
 
-docker-compose up -d neo4j
-neo4j_ready
+docker-compose up -d neo4j &
+start_web_server
+
+cp "$VALIDATION_SCRIPT" "$web_root"/run-script
 
 touch 'config_unit'
 
@@ -50,6 +72,10 @@ for config_unit_path in "$project_root/$CONFIG_UNITS"/*/; do
   [ -z "$config_unit_path" ] && break
 
   unit=$(basename "$config_unit_path")
+  (
+    cd "$project_root/$CONFIG_UNITS/$unit/domain"
+    tar czf "$web_root/$unit.tar.gz" .
+  )
 
   UNIT="$unit" CONF_HOME="$config_unit_path/domain" \
   perl -pe '
@@ -60,16 +86,19 @@ for config_unit_path in "$project_root/$CONFIG_UNITS"/*/; do
     s{PLACE_TO_HIT}{$ENV{CONFIG_TESTER_HEALTH_ENDPOINT}};
     s{STARTUP_ARGUMENTS}{$ENV{CONFIG_TESTER_STARTUP_ARGS}};
     s{CONF_HOME}{$ENV{CONF_HOME}};
-    s{VALIDATION_SCRIPT}{$ENV{VALIDATION_SCRIPT}};
+    s{CONFIG_SERVER}{$ENV{CONFIG_SERVER}};
     s{READY_RESPONSE}{$ENV{CONFIG_TESTER_RESPONSE_READY}};
     ' "$TEMPLATE_DOCKER_COMPOSE" >> "$docker_compose"
 
   echo "$unit" >> 'config_unit'
 done
 
+neo4j_ready
+wait $pull_pid
 check_config_unit
 
 docker-compose down
+stop_web_server
 
 if [ $(grep -c . config_unit) != $(egrep -c 'Config unit \S+ ok' "$conf_check_output") ]
 then

--- a/defaults/docker-resources/docker-compose-template.yml
+++ b/defaults/docker-resources/docker-compose-template.yml
@@ -16,8 +16,16 @@
         CONFIG_UNIT
     depends_on:
       - neo4j
-    volumes:
-      - CONF_HOME:/app/conf/domain
-      - VALIDATION_SCRIPT:/opt/my/runner
-    entrypoint: >-
-      /opt/my/runner
+    entrypoint: |
+      sh -c '
+      command -v apk > /dev/null || (command -v apt-get >/dev/null && apt-get update)
+      command -v curl > /dev/null || apk add curl || apt-get install curl
+      mkdir -p /app/conf/domain
+      (
+        cd /app/conf/domain
+        curl -s http://CONFIG_SERVER/CONFIG_UNIT.tar.gz | tar zx
+      )
+      curl -s http://CONFIG_SERVER/run-script > /tmp/script
+      chmod +x /tmp/script
+      /tmp/script
+      '


### PR DESCRIPTION
As a design decision, runc does not like mounting anything.

Instead of mounting files, we'll set up a couple of things for our containers:

1. a web server with a `run-script` containing $VALIDATION_SCRIPT
2. a tarball containing per configuration

We'll tell our containers to start by downloading the tarball and extracting it.

Then we'll download and run the run-script.

To improve performance, we start neo4j in the background and pull the validation image in the background.

We don't run configuration validation until neo4j is ready, and we wait for the validation image to be available before starting the validators. We expect that the image will arrive before neo4j is ready.