### PR TITLE
Handle the absence of perl

### DIFF
--- a/defaults/testing-resources/test-backend-config.sh
+++ b/defaults/testing-resources/test-backend-config.sh
@@ -4,7 +4,27 @@ set -e
 backend_err=$(mktemp)
 pid_file=$(mktemp)
 
+has_command() {
+  command -v "$1" > /dev/null
+}
+
 show_logs() {
+  if ! has_command perl; then
+  (
+    if has_command apk; then
+      apk add perl
+    elif has_command apt-get; then
+      apt-get update && apt-get install -y perl
+    else
+      false
+    fi
+  ) >/dev/null 2>/dev/null || echo "::warning::could not configure perl" >&2
+  fi
+  if ! has_command perl; then
+    cat "$backend_err"
+    return
+  fi
+
   perl -e '
   my $state=0;
   while (<>) {


### PR DESCRIPTION
Not all images will have perl.

If the image doesn't, and it's alpine based, we can try to add perl using `apk`, if it's debian based, we can try adding it using `apt-get`, otherwise, we can skip the preprocessing and just dump the raw output, which is better than nothing.