### PR TITLE
Change sample tester success response

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   config-tester-success-result:
     description: 'Result associated with success from a config-tester'
     required: false
-    default: '{"databaseConnection":{"Right":{"value":"ok"}}}'
+    default: '{"databaseConnection":{"Right":{"value":"OK.*"}}}'
   config-tester-health-endpoint:
     description: 'Which endpoint to hit to determine success/failure.'
     required: false


### PR DESCRIPTION
As the tester is using `grep`, this allows for the response to have any trailing text after `ok`.

The code does now expect an uppercase `OK` as opposed to a lowercase `ok`, which seems like a better thing stylisitically.