### PR TITLE
Change sample tester success response handling

### DIFF
--- a/defaults/testing-resources/test-backend-config.sh
+++ b/defaults/testing-resources/test-backend-config.sh
@@ -86,7 +86,7 @@ if [ "$BACKEND_HEALTH" = "$BACKEND_SUCCESS_RESULT" ]; then
   exit 0
 fi
 
-echo "<header>Config Unit $Unit is broken</header>"
+echo "<header>Config unit $UNIT is broken</header>"
 echo "$BACKEND_HEALTH" | tr '\n' ' '
 
 show_logs

--- a/defaults/testing-resources/test-backend-config.sh
+++ b/defaults/testing-resources/test-backend-config.sh
@@ -81,7 +81,7 @@ start_backend
 
 BACKEND_HEALTH=$(retrieve "$BACKEND_HEALTH_ENDPOINT")
 
-if [ "$BACKEND_HEALTH" = "$BACKEND_SUCCESS_RESULT" ]; then
+if echo "$BACKEND_HEALTH" | grep -q "$BACKEND_SUCCESS_RESULT"; then
   echo "Config unit $UNIT ok"
   exit 0
 fi


### PR DESCRIPTION
* Fix unit casing
* use `grep -q` to tolerate some variance in backend success result