### PR TITLE
Validate docker-compose.yml

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,11 +1,7 @@
 apk
 gcr
-github
 Guice
 jvm
 mktemp
-pid
-pne
 rabbitmq
-usr
 yml

--- a/action.sh
+++ b/action.sh
@@ -93,6 +93,26 @@ for config_unit_path in "$project_root/$CONFIG_UNITS"/*/; do
   echo "$unit" >> 'config_unit'
 done
 
+if ! docker-compose ps >/dev/null; then
+  echo ::error title=Invalid Configuration::docker compose objected to the configuration
+  (
+    b='`'
+    echo '# Error'
+    echo '```sh'
+    (docker-compose ps >/dev/null || true) 2>&1
+    echo '```'
+    echo
+    echo "<details><summary>$b$docker_compose$b</summary>"
+    echo
+    echo '```yml'
+    cat "$docker_compose"
+    echo '```'
+    echo
+    echo '</details>'
+  ) >> "$GITHUB_STEP_SUMMARY"
+  exit 15
+fi
+
 neo4j_ready
 wait $pull_pid
 check_config_unit


### PR DESCRIPTION
`docker-compose` expects valid yaml. And not all characters that are valid in file paths are valid in yaml.

Instead of trying to write a complete validation, we can ask `docker-compose` if it's happy with the configuration we've generated. If it isn't, then we should die and give people enough information to fix their configuration.

Offhand, I generally suggest people avoid using spaces and parenthesis in paths...